### PR TITLE
Script Action - Apply Damage Engaged

### DIFF
--- a/src/script.cpp
+++ b/src/script.cpp
@@ -907,10 +907,7 @@ int run_script(struct info_script* info, struct script_data* position)
 
         case SCRIPT_APPLY_DMG_ENG:
             // tmpch is the source char (whose engaged gets targeted) and tmpch2 is the char being hit
-            // 50% chance to hit each target, the actual proc chance should happen outside call
-            // general room messages should be handled in script
-            // dont use on weapons, ch1 would be the hitter and it would reverse targets
-
+            // note if used on weapons, ch1 would be the attacker and it would proc on the attackers engaged (reversed)
             if (curr->param[0] && curr->param[1]) {
                 tmpch = get_char_param(curr->param[0], info);
 

--- a/src/script.h
+++ b/src/script.h
@@ -90,10 +90,11 @@
 #define SCRIPT_IF_INT_GREATER 72 //  Test to see whether one integer is greater than another
 #define SCRIPT_IF_INT_TRUE 73 //  Test to see whether one integer is greater than 0
 #define SCRIPT_IF_ROOM_SUNLIT 74 // Check to see if there is sunlight in the room
-
 #define SCRIPT_TELEPORT_CHAR_XL 75 //  Take char_from_room then put chX.room (leave followers behind)
 #define SCRIPT_IF_INT_FALSE 76 //  Test to see whether one integer is less than 1
 #define SCRIPT_LOAD_OBJ_X 77 //  Load an object from another object - note this object is not placed in the game
+#define SCRIPT_APPLY_DMG_ENG 78 // Do damage towards all engaged victims
+
 
 #define SCRIPT_COMMAND_NONE 99 //  Given to new or unused commands
 // 999 - reserved for script loading - do not use

--- a/src/shapescript.cpp
+++ b/src/shapescript.cpp
@@ -685,7 +685,7 @@ void show_command(char_data* ch, script_data* script)
 
     case SCRIPT_APPLY_DMG_ENG:
         sprintf(buf, "[%d] ACT APPLY_DMG_ENG    (of char: %s, dmg: %s, type: %s)\n\r", script->number,
-            get_param_text(script->param[0]), get_param_text(script->param[1]), get_param_text(script->param[2]));
+            get_param_text(script->param[0]), get_param_text(script->param[1]), get_param_text(script->param[2]), script->text);
         break;
 
     case SCRIPT_DO_REMOVE:
@@ -1644,7 +1644,7 @@ void shape_center_script(struct char_data* ch, char* arg)
                 break;
 
             case SCRIPT_APPLY_DMG_ENG:
-                SCRIPTPARAMCHANGE("Enter mob (ch1), rand dmg(int), and optional dmg type (int)", 3);
+                SCRIPTPARAMCHANGE("Enter mob (ch1), rand dmg(int), and optional dmg type (int), msg", 3);
                 SHAPE_SCRIPT(ch)
                     ->editflag
                     = 5;

--- a/src/shapescript.cpp
+++ b/src/shapescript.cpp
@@ -683,6 +683,11 @@ void show_command(char_data* ch, script_data* script)
             get_param_text(script->param[0]), get_param_text(script->param[1]));
         break;
 
+    case SCRIPT_APPLY_DMG_ENG:
+        sprintf(buf, "[%d] ACT APPLY_DMG_ENG    (of char: %s, dmg: %s, type: %s)\n\r", script->number,
+            get_param_text(script->param[0]), get_param_text(script->param[1]), get_param_text(script->param[2]));
+        break;
+
     case SCRIPT_DO_REMOVE:
         sprintf(buf, "[%d] ACT DO_REMOVE        character: %s, position: %d (%s)\n\r", script->number,
             get_param_text(script->param[0]), script->param[1], script->text);
@@ -1638,6 +1643,13 @@ void shape_center_script(struct char_data* ch, char* arg)
                     = 5;
                 break;
 
+            case SCRIPT_APPLY_DMG_ENG:
+                SCRIPTPARAMCHANGE("Enter mob (ch1), rand dmg(int), and optional dmg type (int)", 3);
+                SHAPE_SCRIPT(ch)
+                    ->editflag
+                    = 5;
+                break;
+
             case SCRIPT_DO_REMOVE:
                 SCRIPTPARAMCHANGE("Enter character and equipment position (eg ch1 16):", 2);
                 SHAPE_SCRIPT(ch)
@@ -2290,6 +2302,8 @@ int get_command(char* command)
             return SCRIPT_ASSIGN_ROOM;
         if (!strcmp(command, "ASSIGN_STR"))
             return SCRIPT_ASSIGN_STR;
+        if (!strcmp(command, "APPLY_DMG_ENG"))
+            return SCRIPT_APPLY_DMG_ENG;
         return 0;
 
     case 'B':


### PR DESCRIPTION
- Can select multiple targets that are combat engaged to chX
- Takes a baseline int value for damage and randoms it a little
- Checks armor for reduction
- Damage type can be passed, default is conc

**Scripting Notes:**
- Only on Mob, it would reverse targets if on weapon
- Handle chances to proc in script, this assumes a hit, and each eng tgt gets 50% to miss
- A general room message should happen outside, this will only msg a hit characters

**Syntax:**  (of char: ch1, dmg: int2, type: int1)   +  comment
- ch1: the source mob
- middle dmg (its rand range of +- 10%)
- damage_type
- Comment is the message to hit character. If you place "CH1" it is replaced with the mob's name.