### PR TITLE
Tames: Remove from Zone Command

### DIFF
--- a/src/ranger.cpp
+++ b/src/ranger.cpp
@@ -21,6 +21,7 @@
 #include "spells.h"
 #include "structs.h"
 #include "utils.h"
+#include "zone.h" /* For zone_table */
 
 #include "big_brother.h"
 #include "char_utils.h"
@@ -1574,8 +1575,17 @@ ACMD(do_tame)
                 return;
             }
 
-            if (victim->master)
+            if (victim->master) {
                 stop_follower(victim, FOLLOW_MOVE);
+            }
+
+            if (GET_LOADLINE(victim)) {
+                zone_table[GET_LOADZONE(victim)].cmd[GET_LOADLINE(victim) - 1].existing--;
+                if (zone_table[GET_LOADZONE(victim)].cmd[GET_LOADLINE(victim) - 1].existing < 0) {
+                    zone_table[GET_LOADZONE(victim)].cmd[GET_LOADLINE(victim) - 1].existing = 0;
+                }
+            }
+
             affect_from_char(victim, SKILL_TAME);
             add_follower(victim, ch, FOLLOW_MOVE);
 


### PR DESCRIPTION
Removes the mob from the zone command counter, when tame is successful, so that the zone can load a new one.