### PR TITLE
Updated should_assist_master

### DIFF
--- a/src/act_offe.cpp
+++ b/src/act_offe.cpp
@@ -158,7 +158,7 @@ bool should_assist_master(char_data *ch) {
         return false;
     }
 
-    if (IS_NPC(ch)) {
+    if (IS_NPC(ch) && IS_NPC(master)) {
         return false;
     }
 


### PR DESCRIPTION
Added a check to make sure that the master wasn't an NPC and if not allow for just the default command of `order follower assist`.