### PR TITLE
Reset programs stored in mob_index

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1233,6 +1233,7 @@ struct char_data *read_mobile(int nr, int type) {
   character_list = mob;
 
   mob_index[i].number++;
+  mob_index[i].func = 0;
 
   register_npc_char(mob);
 

--- a/src/mobact.cpp
+++ b/src/mobact.cpp
@@ -114,6 +114,8 @@ void one_mobile_activity(char_data* ch)
 
         /* Examine call for special procedure */
         if (IS_SET(ch->specials2.act, MOB_SPEC) && !no_specials) {
+            sprintf(buf, "%s - find prog: %d, func:%d",  GET_NAME(ch), ch->specials2.act, mob_index[ch->nr].func);
+            mudlog_aliased_mob(buf, ch, "progdebug");
             if (!mob_index[ch->nr].func && ch->specials.store_prog_number) {
                 tmpfunc = (SPECIAL(*))virt_program_number(ch->specials.store_prog_number);
                 if (tmpfunc) {


### PR DESCRIPTION
See #258 

- To fix the issue, I reset the value of mob_index[nr].func to 0 on read_mobile.
- Added test output for mob with alias "progdebug" to display the mob's flag_number value and active program. When activated, it will show if this error is occurring again.