### PR TITLE
Bug Fix: Scripts Stuck in Memory and Execute on Death

### DIFF
--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -878,7 +878,7 @@ void raw_kill(char_data* dead_man, char_data* killer, int attack_type)
 {
     waiting_type tmpwtl;
 
-    if ((dead_man->delay.wait_value >= 0) && (dead_man->delay.cmd > 0)) {
+    if ((dead_man->delay.wait_value > 0) && (dead_man->delay.cmd > 0)) {
         dead_man->delay.subcmd = -1;
         complete_delay(dead_man);
     }

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1547,6 +1547,7 @@ void continue_char_script(char_data* ch)
 
     initialise_script_info_char(ch, -1); // Invalidates all pointers, but its safter this way
     ch->specials.script_info->ch[0] = ch;
+    ch->delay.cmd = 0;
     return_value = run_script(ch->specials.script_info, ch->specials.script_info->next_command);
 }
 


### PR DESCRIPTION
The last line executed of scripts on a mob would be repeated on death. You could see an affected mob by statting it and seeing "Delay command:9999 delay_value:0".