### PR TITLE
Handle crashes when a character's hit points go negative

### DIFF
--- a/src/act_info.cpp
+++ b/src/act_info.cpp
@@ -440,16 +440,18 @@ void show_equipment_to_char(struct char_data *from, struct char_data *to) {
 extern struct prompt_type health_diagnose[];
 
 void report_char_health(struct char_data *ch, struct char_data *i, char *str) {
-    int tmp, percent;
+    int tmp;
+    long long percent; // widen so 1000 * GET_HIT(i) cannot signed-overflow
+    const int max_index = 7; // health_diagnose[] has 8 entries (consts.cpp)
 
     strcpy(str, PERS(i, ch, TRUE, FALSE));
 
     if (GET_MAX_HIT(i) > 0)
-        percent = (1000 * GET_HIT(i)) / GET_MAX_HIT(i);
+        percent = (1000LL * GET_HIT(i)) / GET_MAX_HIT(i);
     else
         percent = -1;
 
-    for (tmp = 0; health_diagnose[tmp].value < percent; tmp++)
+    for (tmp = 0; tmp < max_index && health_diagnose[tmp].value < percent; tmp++)
         ;
 
     strcat(str, health_diagnose[tmp].message);
@@ -3016,7 +3018,7 @@ void add_prompt(char *prompt, struct char_data *ch, long flag) {
     }
     if (GET_MAX_HIT(ch))
         if (flag & PROMPT_HIT) {
-            for (tmp = 0; (1000 * GET_HIT(ch)) / GET_MAX_HIT(ch) > prompt_hit[tmp].value; tmp++)
+            for (tmp = 0; tmp < 7 && (1000LL * GET_HIT(ch)) / GET_MAX_HIT(ch) > prompt_hit[tmp].value; tmp++)
                 ;
             if ((GET_HIT(ch) != GET_MAX_HIT(ch)) || (ch->specials.position == POSITION_FIGHTING))
                 sprintf(prompt, "%s%s%c", prompt, prompt_hit[tmp].message, 0);

--- a/src/act_othe.cpp
+++ b/src/act_othe.cpp
@@ -356,7 +356,9 @@ void print_group_leader(const char_data *leader) {
 
     // For loop just gets prompt indices to the correct spot.
     for (health_prompt_index = 0;
-         (1000 * GET_HIT(leader)) / GET_MAX_HIT(leader) > prompt_hit[health_prompt_index].value;
+         health_prompt_index < 7 &&
+         (1000LL * GET_HIT(leader)) / (GET_MAX_HIT(leader) == 0 ? 1 : GET_MAX_HIT(leader)) >
+             prompt_hit[health_prompt_index].value;
          health_prompt_index++)
         ;
 
@@ -390,7 +392,8 @@ void print_group_member(const char_data *group_member) {
 
     // For loop just gets prompt indices to the correct spot.
     for (health_prompt_index = 0;
-         (1000 * GET_HIT(group_member)) /
+         health_prompt_index < 7 &&
+         (1000LL * GET_HIT(group_member)) /
              (GET_MAX_HIT(group_member) == 0 ? 1 : GET_MAX_HIT(group_member)) >
          prompt_hit[health_prompt_index].value;
          health_prompt_index++)
@@ -611,7 +614,7 @@ ACMD(do_report) {
         return;
     }
 
-    for (tmp1 = 0; (1000 * GET_HIT(ch)) / GET_MAX_HIT(ch) > prompt_hit[tmp1].value; tmp1++)
+    for (tmp1 = 0; tmp1 < 7 && (1000LL * GET_HIT(ch)) / (GET_MAX_HIT(ch) == 0 ? 1 : GET_MAX_HIT(ch)) > prompt_hit[tmp1].value; tmp1++)
         ;
     for (tmp2 = 0; (1000 * GET_MANA(ch)) / GET_MAX_MANA(ch) > prompt_mana[tmp2].value; tmp2++)
         ;

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -730,9 +730,19 @@ void point_update(void) {
              * without ever going through damage()'s own die() call.
              * Pick that up here instead of leaving a character stuck
              * "dead" forever: safe to call die() with NULL killer from
-             * this loop (next_dude is already captured above, and
-             * fast_update()'s regen-death path already establishes the
-             * same NULL-killer pattern).
+             * this loop (next_dude is already captured above, the same
+             * mid-walk-deletion safety fight.cpp's combat_next_dude
+             * relies on). do_quit() (act_othe.cpp) already calls
+             * die(ch, 0, 0) for a player who quits below
+             * POSITION_STUNNED - the same "no external killer, character
+             * just expires from their own state" case - so that's the
+             * precedent here, not fast_update()'s regen-death branch
+             * (which calls raw_kill() directly and skips the ON_DIE
+             * trigger and exp/PK/exploit bookkeeping die() performs).
+             * Going through die() here is intentional: scripted damage
+             * that lands someone at POSITION_DEAD should still be able
+             * to trigger ON_DIE side effects, same as an ordinary
+             * combat death.
              *
              * Re-derive position from current hit first: fast_update()'s
              * passive regen never calls update_pos(), so a character

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -48,6 +48,7 @@ extern struct char_data *death_waiting_list;
 void recalc_skills(struct char_data *ch);
 
 extern void raw_kill(char_data *ch, char_data *killer, int attacktype);
+extern void die(char_data *dead_man, char_data *killer, int attack_type);
 void one_mobile_activity(char_data *ch);
 
 #define MIN_RANK 1
@@ -723,6 +724,28 @@ void point_update(void) {
 
         } else if (GET_POS(i) == POSITION_INCAP)
             damage(i, i, 3, TYPE_SUFFERING, 0);
+        else if (GET_POS(i) == POSITION_DEAD) {
+            /* A character can land directly at POSITION_DEAD via a
+             * script write to hit (see set_int_value()/int_fromstack())
+             * without ever going through damage()'s own die() call.
+             * Pick that up here instead of leaving a character stuck
+             * "dead" forever: safe to call die() with NULL killer from
+             * this loop (next_dude is already captured above, and
+             * fast_update()'s regen-death path already establishes the
+             * same NULL-killer pattern).
+             *
+             * Re-derive position from current hit first: fast_update()'s
+             * passive regen never calls update_pos(), so a character
+             * parked at DEAD by a scripted hit only just past the
+             * -CON/2 threshold may have already healed back to positive
+             * hit by the time this sweep runs. Don't kill on a stale
+             * position. */
+            update_pos(i);
+            if (GET_POS(i) == POSITION_DEAD) {
+                die(i, NULL, TYPE_UNDEFINED);
+                continue;
+            }
+        }
     } /* for */
 
     /* objects */

--- a/src/mudlle.cpp
+++ b/src/mudlle.cpp
@@ -1,4 +1,5 @@
 #include "platdef.h"
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -7,6 +8,7 @@
 #include "db.h"
 #include "handler.h"
 #include "interpre.h"
+#include "limits.h"
 #include "mudlle.h"
 #include "protos.h"
 #include "structs.h"
@@ -599,6 +601,16 @@ void question_proc(struct char_data* host)
 }
 
 /*
+ * A script may write directly into a character's hit points via
+ * the 'h' case below, bypassing update_pos()/normal death processing
+ * entirely.  Clamp to a range far beyond any real character's hit
+ * points but well inside int range (mirrors script.cpp's
+ * MIN/MAX_SCRIPT_HIT_VALUE for the SET_INT_VALUE opcode).
+ */
+static const int MIN_MUDLLE_HIT_VALUE = -1000000;
+static const int MAX_MUDLLE_HIT_VALUE = 1000000;
+
+/*
  * Sets parameters of the item in list, taking
  * them from the stack.
  */
@@ -615,10 +627,30 @@ void int_fromstack(struct char_data* host, char* arg, int cmd,
         break;
 
     case 'h':
-        if ((SPECIAL_LIST_TYPE(host) == TARGET_CHAR) && (SPECIAL_LIST(host).ptr.ch))
-            SPECIAL_LIST(host)
-                .ptr.ch->tmpabilities.hit
-                = val;
+        if ((SPECIAL_LIST_TYPE(host) == TARGET_CHAR) && (SPECIAL_LIST(host).ptr.ch)) {
+            char_data* target = SPECIAL_LIST(host).ptr.ch;
+            val = std::max(MIN_MUDLLE_HIT_VALUE, std::min(val, MAX_MUDLLE_HIT_VALUE));
+            target->tmpabilities.hit = val;
+            /* Only resync when the write pushes hit non-positive, or
+             * when the character was already sitting at DEAD/INCAP/
+             * STUNNED from an earlier script write and needs releasing
+             * now that they've been healed - not on every positive
+             * write, since update_pos() forces STANDING/FIGHTING
+             * whenever hit > 0 (would wrongly stand up a resting/
+             * sleeping character). Without the second condition a
+             * character healed from a prior scripted DEAD/INCAP/
+             * STUNNED would stay stuck at that stale position - a
+             * soft-lock until the next point_update() sweep, since the
+             * command dispatcher requires a higher position for nearly
+             * everything. POSITION_SHAPING is deliberately excluded -
+             * it's the OLC "shape" editor state (interpre.cpp),
+             * unrelated to dying. */
+            bool already_dying = GET_POS(target) == POSITION_DEAD ||
+                GET_POS(target) == POSITION_INCAP ||
+                GET_POS(target) == POSITION_STUNNED;
+            if (val <= 0 || already_dying)
+                update_pos(target);
+        }
         break;
 
     case 'm':

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -17,6 +17,7 @@
 // returns 1 if program should continue as normal, 0 if not (eg on_die 0 == do not kill char)
 
 #include "platdef.h"
+#include <algorithm>
 #include <ctype.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -260,6 +261,17 @@ int is_int_param_writable(int param)
 }
 
 /*
+ * A script may write directly into a character's hit points via
+ * SET_INT_VALUE (chX.hit), bypassing update_pos()/normal death
+ * processing entirely.  Clamp to a range far beyond any real
+ * character's hit points but well inside int range, so downstream
+ * code that scales GET_HIT() (e.g. report_char_health(), add_prompt())
+ * can't be handed a pathological value.
+ */
+static const int MIN_SCRIPT_HIT_VALUE = -1000000;
+static const int MAX_SCRIPT_HIT_VALUE = 1000000;
+
+/*
  * Set dest to val if dest is a valid destination.  dest
  * should refer to one of the settable variables in a script,
  * such as chx.hit.
@@ -274,9 +286,55 @@ void set_int_value(struct info_script* info, int param, int val)
     if (x == NULL)
         return;
 
-    if (is_int_param_writable(param))
+    if (is_int_param_writable(param)) {
+        char_data* affected_ch = NULL;
+
+        switch (param) {
+        case SCRIPT_PARAM_CH1_HIT:
+            val = std::max(MIN_SCRIPT_HIT_VALUE, std::min(val, MAX_SCRIPT_HIT_VALUE));
+            affected_ch = info->ch[0];
+            break;
+        case SCRIPT_PARAM_CH2_HIT:
+            val = std::max(MIN_SCRIPT_HIT_VALUE, std::min(val, MAX_SCRIPT_HIT_VALUE));
+            affected_ch = info->ch[1];
+            break;
+        case SCRIPT_PARAM_CH3_HIT:
+            val = std::max(MIN_SCRIPT_HIT_VALUE, std::min(val, MAX_SCRIPT_HIT_VALUE));
+            affected_ch = info->ch[2];
+            break;
+        default:
+            break;
+        }
+
         *x = val;
-    else
+
+        /* Keep GET_POS() consistent with the new hit value instead of
+         * leaving a character "alive" per position but lethally
+         * wounded per hit (see update_pos(), fight.cpp). Only resync
+         * when the write pushes hit non-positive, or when the
+         * character was already sitting at DEAD/INCAP/STUNNED from an
+         * earlier script write and needs releasing now that they've
+         * been healed - not on every positive write, since update_pos()
+         * forces STANDING/FIGHTING whenever hit > 0, which would
+         * wrongly yank a resting/sitting/sleeping character to their
+         * feet just because a script topped up their hit (e.g. a heal
+         * effect). Without the second condition, a character healed
+         * back to positive from a prior scripted DEAD/INCAP/STUNNED
+         * would stay stuck at that stale position - and since the
+         * command dispatcher requires position above it for nearly
+         * everything, that's a soft-lock until the next point_update()
+         * sweep happens to notice and release them. POSITION_SHAPING is
+         * deliberately excluded here - it's the OLC "shape" editor
+         * state (interpre.cpp), unrelated to dying, and shouldn't be
+         * disturbed by a positive hit write. */
+        if (affected_ch) {
+            bool already_dying = GET_POS(affected_ch) == POSITION_DEAD ||
+                GET_POS(affected_ch) == POSITION_INCAP ||
+                GET_POS(affected_ch) == POSITION_STUNNED;
+            if (val <= 0 || already_dying)
+                update_pos(affected_ch);
+        }
+    } else
         vmudlog(BRF, "Script #%d tried to write to unwritable "
                      "integer parameter %s",
             script_table[info->index].number,
@@ -307,9 +365,11 @@ int int_binary_op(struct info_script* info, int command, int* a, int* b)
     case SCRIPT_SET_INT_DIV:
         if (*b != 0)
             return *a / *b;
-        else
+        else {
             vmudlog(BRF, "Script #%d tried to divide by 0.",
                 script_table[info->index].number);
+            return 0;
+        }
     case SCRIPT_SET_INT_RANDOM:
         return number(*a, *b);
     default:


### PR DESCRIPTION
SET_INT_VALUE (and other script int operators, which all funnel through the same write function) could write an arbitrary unvalidated int into a character's hit points. report_char_health()/add_prompt()/ print_group_leader()/print_group_member()/do_report() then scanned a fixed 8-entry health/status array with no bound on the loop index, overrunning it whenever the computed health percent exceeded 1000 - via integer overflow on extreme values, or just an ordinary hit paired with a small max_hit. Bound those scans so the overrun is impossible regardless of how hit went negative (combat, regen, poison, or script).

Clamp the script write paths (script.cpp's SET_INT_VALUE and mudlle's 'h' opcode) and resync position via update_pos() when the result is non-positive, or when the character was already parked at a stale DEAD/INCAP/STUNNED position from an earlier script write and needs releasing now that they've recovered - avoids both leaving a character "alive" per position while lethally wounded, and a soft-lock where a healed character stays stuck below the position required for nearly every command. Deliberately does not disengage them from their current combat target on incapacitation (differs from damage()'s own behavior), and does not call die()/stop_fighting() from these paths to avoid re-entrant script/trigger execution against live pointers.

Since the position resync can land a character directly at POSITION_DEAD without going through damage()'s own die() call, extend point_update()'s sweep to pick up stray POSITION_DEAD characters and kill them safely from the main pulse loop, re-deriving position from current hit first so a character who naturally regenerated back to health isn't wrongly killed on a stale value.

Also fixes a fallthrough bug in SET_INT_DIV: dividing by zero fell through into the RANDOM case instead of returning cleanly.