### PR TITLE
Sanitize MSDP string values so clients can safely parse them as JSON

### DIFF
--- a/src/act_move.cpp
+++ b/src/act_move.cpp
@@ -598,7 +598,7 @@ void msdp_room_update(char_data *ch) {
     msdp_room += (char)MSDP_VAR;
     msdp_room += "NAME";
     msdp_room += (char)MSDP_VAL;
-    msdp_room += world[ch->in_room].name;
+    msdp_room += MSDPSanitizeValue(world[ch->in_room].name);
     msdp_room += (char)MSDP_VAR;
     msdp_room += "EXITS";
     msdp_room += (char)MSDP_VAL;

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -440,9 +440,11 @@ void msdp_update() {
         auto sector_type = world[desc->character->in_room].sector_type;
         auto weather_type = weather_info.sky[sector_type];
         extern char *weather_messages[8][13];
+        extern std::string strip_trailing_line_break(const char* text);
 
         if (OUTSIDE(desc->character)) {
-            MSDPSetString(desc, eMDSP_WEATHER, weather_messages[weather_type + 2][sector_type]);
+            MSDPSetString(desc, eMDSP_WEATHER,
+                strip_trailing_line_break(weather_messages[weather_type + 2][sector_type]).c_str());
         } else {
             MSDPSetString(desc, eMDSP_WEATHER, "You can have no feeling about the weather here.");
         }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <string>
+
 #include "protocol.h"
 
 /******************************************************************************
@@ -1251,14 +1253,56 @@ void MSDPSetNumber(descriptor_t *apDescriptor, variable_t aMSDP, int aValue) {
     }
 }
 
+std::string MSDPSanitizeValue(const char *apValue) {
+    std::string Result;
+
+    if (apValue == NULL) {
+        return Result;
+    }
+
+    Result.reserve(strlen(apValue));
+
+    for (const unsigned char *p = (const unsigned char *)apValue; *p != '\0'; ++p) {
+        switch (*p) {
+        case '\"':
+            Result += "\\\"";
+            break;
+        case '\\':
+            Result += "\\\\";
+            break;
+        case '\n':
+            Result += "\\n";
+            break;
+        case '\r':
+            Result += "\\r";
+            break;
+        case '\t':
+            Result += "\\t";
+            break;
+        default:
+            if (*p < 0x20) {
+                char Escape[8];
+                sprintf(Escape, "\\u%04x", *p);
+                Result += Escape;
+            } else {
+                Result += (char)*p;
+            }
+        }
+    }
+
+    return Result;
+}
+
 void MSDPSetString(descriptor_t *apDescriptor, variable_t aMSDP, const char *apValue) {
     protocol_t *pProtocol = apDescriptor ? apDescriptor->pProtocol : NULL;
 
     if (pProtocol != NULL && apValue != NULL) {
         if (VariableNameTable[aMSDP].bString) {
-            if (strcmp(pProtocol->pVariables[aMSDP]->pValueString, apValue)) {
+            std::string SanitizedValue = MSDPSanitizeValue(apValue);
+
+            if (strcmp(pProtocol->pVariables[aMSDP]->pValueString, SanitizedValue.c_str())) {
                 free(pProtocol->pVariables[aMSDP]->pValueString);
-                pProtocol->pVariables[aMSDP]->pValueString = AllocString(apValue);
+                pProtocol->pVariables[aMSDP]->pValueString = AllocString(SanitizedValue.c_str());
                 pProtocol->pVariables[aMSDP]->bDirty = true;
             }
         }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -10,6 +10,8 @@
 #ifndef PROTOCOL_H
 #define PROTOCOL_H
 
+#include <string>
+
 /******************************************************************************
  Set your MUD_NAME, and change descriptor_t if necessary.
  ******************************************************************************/
@@ -483,8 +485,22 @@ void MSDPSetNumber( descriptor_t *apDescriptor, variable_t aMSDP, int aValue );
  * approach is to send every MSDP variable within an update function (and
  * this is what the snippet does by default), but if the variable is only
  * set in one place you can just move its MDSPSend() call to there.
+ *
+ * The value is passed through MSDPSanitizeValue() first, so it stays a
+ * valid JSON string for clients that convert MSDP into JSON.
  */
 void MSDPSetString( descriptor_t *apDescriptor, variable_t aMSDP, const char *apValue );
+
+/* Function: MSDPSanitizeValue
+ *
+ * Returns a copy of apValue with characters that are illegal inside a bare
+ * JSON string ('"', '\', and control characters such as \n and \r) replaced
+ * by their standard JSON escape sequence. MSDPSetString() applies this
+ * automatically; call it directly when hand-building a table/array value
+ * (see MSDPSetTable) that embeds freeform text, since those bypass
+ * MSDPSetString().
+ */
+std::string MSDPSanitizeValue( const char *apValue );
 
 /* Function: MSDPSetTable
  *

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -157,6 +157,17 @@ void weather_to_char(char_data* ch);
 
 extern char* moon_phase[];
 
+// weather_messages[] entries end in "\n\r" for direct display to the
+// terminal; MSDP values are discrete data, not display text, so strip it.
+std::string strip_trailing_line_break(const char* text)
+{
+    std::string result(text);
+    while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
+        result.pop_back();
+    }
+    return result;
+}
+
 void send_msdp_function(void (*func)(descriptor_data* desc))
 {
     extern struct descriptor_data *descriptor_list;
@@ -551,7 +562,8 @@ void weather_change(void)
         auto sector_type = world[desc->character->in_room].sector_type;
         auto weather_type = weather_info.sky[sector_type];
         if (OUTSIDE(desc->character)) {
-            MSDPSetString(desc, eMDSP_WEATHER, weather_messages[weather_type + 2][sector_type]);
+            MSDPSetString(desc, eMDSP_WEATHER,
+                strip_trailing_line_break(weather_messages[weather_type + 2][sector_type]).c_str());
         } else {
             MSDPSetString(desc, eMDSP_WEATHER, "You can have no feeling about the weather here.");
         }


### PR DESCRIPTION
Some clients (e.g. Mudlet) convert MSDP variable/value pairs into JSON, which breaks if a value contains an unescaped control character, quote, or backslash. weather_messages[] entries end in a literal "\n\r" for direct terminal display, and that same raw string was being sent as the WEATHER MSDP value, producing invalid JSON on the client side.

- Add MSDPSanitizeValue() and apply it in MSDPSetString(), escaping '"', '\', and control characters for every MSDP string variable.
- Apply it explicitly where act_move.cpp hand-builds the ROOM table's NAME field, since MSDPSetTable() bypasses MSDPSetString().
- Strip the trailing "\n\r" off weather_messages[] before using it as the WEATHER value, since it's data, not display text.