### PR TITLE
fix(msdp): send room MSDP data on reconnect, not just fresh login

### DIFF
--- a/src/interpre.cpp
+++ b/src/interpre.cpp
@@ -2761,6 +2761,10 @@ void complete_existing_character_login(struct descriptor_data* d, int load_resul
             REMOVE_BIT(PLR_FLAGS(d->character), PLR_MAILING | PLR_WRITING);
             clear_account_backed_object_bytes_for_character(d->character);
             STATE(d) = CON_PLYNG;
+            if (!d->pProtocol)
+                d->pProtocol = ProtocolCreate();
+            ProtocolNegotiate(d);
+            msdp_room_update(d->character);
             vmudlog(NRM, "%s [%s] has reconnected.", GET_NAME(d->character), d->host);
             return;
         }
@@ -4054,6 +4058,10 @@ void nanny(struct descriptor_data* d, char* arg)
                     tmp_ch->specials.timer = 0;
                     REMOVE_BIT(PLR_FLAGS(d->character), PLR_MAILING | PLR_WRITING);
                     STATE(d) = CON_PLYNG;
+                    if (!d->pProtocol)
+                        d->pProtocol = ProtocolCreate();
+                    ProtocolNegotiate(d);
+                    msdp_room_update(d->character);
                     return;
                 }
             }


### PR DESCRIPTION
Two of the four code paths that bring a descriptor into CON_PLYNG skip ProtocolNegotiate()/msdp_room_update() -- the "reconnect to an unswitched character" branch and a redundant quick-reconnect branch in nanny()'s CON_SLCT handler. ROOM and ROOM_EXITS are only ever populated by that one-shot call (unlike other MSDP stats, which self-heal via the periodic per-pulse diff-based refresh), so reconnecting clients were left with stale/missing room data until their next move.

Live-verified via a scripted MSDP-negotiating telnet client: switched into a mob, hard-disconnected, reconnected -- confirmed ROOM, ROOM_EXITS, and CHARACTER_NAME were missing pre-fix and present post-fix, matching a fresh login.